### PR TITLE
Treat EINTR the same as EAGAIN/EWOULDBLOCK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,29 +15,25 @@ jobs:
       uses: actions/checkout@v2
     -
       name: Setup Lua
-      uses: leafo/gh-actions-lua@v8
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
     -
       name: Run luacheck
       run: |
-        luacheck .
+        luacheck --no-self .
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-openresty"
-          - "luajit-2.0.5"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
     -
       name: Checkout
@@ -46,12 +42,9 @@ jobs:
         submodules: 'true'
     -
       name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8
+      uses: mah0x211/setup-lua@v1
       with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
+        versions: ${{ matrix.lua-version }}
     -
       name: Install
       run: |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ if the non-blocking flag is not set in `file`, then writev function will block u
 
 - `n:integer`: number of bytes written.
 - `err:any`: error object.
-- `again:boolean`: `true` if the write operation is incomplete with `EAGAIN` or `EWOULDBLOCK` error.
+- `again:boolean`: `true` if the write operation is incomplete with `EAGAIN`, `EWOULDBLOCK` or `EINTR` error.
 - `remain:string`: the remaining data that could not be written. if `again` is `true`, then the `remain` is a string that contains the remaining data that could not be written.
 
 

--- a/src/writev.c
+++ b/src/writev.c
@@ -56,12 +56,9 @@ static int writev_lua(lua_State *L)
     lua_concat(L, narg - 1);
     str = lua_tolstring(L, 2, &len);
 
-RETRY:
     n = write(fd, str, len);
     if (n == -1) {
-        if (errno == EINTR) {
-            goto RETRY;
-        } else if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
             // again
             lua_pushinteger(L, 0);
             lua_pushnil(L);


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Lua projects and improves the handling and documentation of interrupted system calls in the `writev` function. The main changes are grouped into workflow improvements and code/documentation enhancements.

**Workflow improvements:**

* Replaces the use of `leafo/gh-actions-lua` and `leafo/gh-actions-luarocks` with `mah0x211/setup-lua@v1` for setting up Lua and Luarocks in `.github/workflows/test.yml`, simplifying the CI setup. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L18-R36) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L49-R47)
* Updates the matrix Lua versions in the CI workflow to use new version tags (e.g., `"5.1.:latest"`, `"lj-v2.1:latest"`).

**Code and documentation enhancements:**

* Changes the `writev_lua` function in `src/writev.c` to treat `EINTR` (interrupted system call) the same as `EAGAIN` and `EWOULDBLOCK`, returning `again = true` instead of retrying the write, which improves non-blocking behavior.
* Updates the `README.md` to document that `again` is `true` not only for `EAGAIN` and `EWOULDBLOCK`, but also for `EINTR` errors, keeping the documentation consistent with the code.