### PR TITLE
Change writev to accept table argument 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
         sh ./covgen.sh
     -
       name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/test/writev_test.lua
+++ b/test/writev_test.lua
@@ -16,7 +16,7 @@ function testcase.writev()
 
     -- test that write specified strings to a file
     local n, again, remain
-    n, err, again, remain = writev(w:fd(), 'hello', nil, ' writev ', 'world')
+    n, err, again, remain = writev(w:fd(), {'hello', nil, ' writev ', 'world'})
     assert.is_nil(err)
     assert.is_nil(again)
     assert.is_nil(remain)
@@ -25,22 +25,22 @@ function testcase.writev()
 
     -- test that return again=true even if a little extra capacity is available.
     assert(w:write(string.rep('a', cap - 11)))
-    n, err, again, remain = writev(w:fd(), 'hello', ' writev ', 'world')
+    n, err, again, remain = writev(w:fd(), {'hello', ' writev ', 'world'})
     assert.is_nil(err)
     assert.is_true(again)
-    assert.equal(remain, 'hello writev world')
+    assert.equal(remain, {'hello', ' writev ', 'world'})
     assert.equal(n, 0)
 
     -- test that return nil if peer closed
     r:close()
-    n, err, again, remain = writev(w:fd(), 'hello', ' writev ', 'world')
+    n, err, again, remain = writev(w:fd(), {'hello', ' writev ', 'world'})
     assert.is_nil(err)
     assert.is_nil(again)
     assert.is_nil(n)
     assert.is_nil(remain)
 
     -- test that throws an error if invalid file descriptor
-    n, err, again, remain = writev(123456789, 'hello', ' writev ', 'world')
+    n, err, again, remain = writev(123456789, {'hello', ' writev ', 'world'})
     assert.match(err, 'EBADF')
     assert.is_nil(n)
     assert.is_nil(again)
@@ -48,18 +48,18 @@ function testcase.writev()
 
     -- test that throws an error if no string argument specified
     err = assert.throws(writev, w:fd())
-    assert.match(err, '#2 .+string expected, got no value', false)
+    assert.match(err, '#2 .+table expected, got no value', false)
 
     -- test that throws an error if invalid string argument
-    err = assert.throws(writev, w:fd(), 'hello', 123, 'world')
-    assert.match(err, '#3 .+string expected, got number', false)
+    err = assert.throws(writev, w:fd(), {'hello', 123, 'world'})
+    assert.match(err, 'table#2.+string expected, got number', false)
 end
 
 function testcase.writev_to_file()
     local f = assert(io.tmpfile())
 
     -- test that write to a file
-    local n, err, again = writev(f, 'hello', ' writev ', 'world')
+    local n, err, again = writev(f, {'hello', ' writev ', 'world'})
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(n, 18)


### PR DESCRIPTION
This pull request refactors the `writev` Lua function to accept a table of strings (vectorized I/O) instead of a variable number of string arguments, updating the implementation, documentation, and tests accordingly. This change improves efficiency, makes the API more consistent, and clarifies the handling of partial writes and nil values.

**API and Implementation Changes:**

* The `writev` function now takes a table of strings as its second argument, instead of variadic string arguments. Nil entries in the table are treated as empty strings. [[1]](diffhunk://#diff-41a3772d291693f5f3fbe25064061fb15604e191d0a979176d32be4fb0ab656cR22-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R24) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R60)
* The C implementation in `src/writev.c` is updated to process the table, build the iovec array, and handle partial writes by returning a table of remaining data. Error handling and parameter checking are also updated. [[1]](diffhunk://#diff-41a3772d291693f5f3fbe25064061fb15604e191d0a979176d32be4fb0ab656cR22-R74) [[2]](diffhunk://#diff-41a3772d291693f5f3fbe25064061fb15604e191d0a979176d32be4fb0ab656cL73-R118)

**Documentation Updates:**

* The `README.md` is revised to describe the new table-based API, clarify function parameters, return values (especially for partial writes), and provide updated usage examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R60)

**Test Suite Updates:**

* All test cases in `test/writev_test.lua` are updated to use the new table-based API. Tests now check for correct error messages and behavior with the new argument format. [[1]](diffhunk://#diff-989a69580b58016ca079d4bfd33ee67d01abfed1daa239f998819c3708d53c7cL19-R19) [[2]](diffhunk://#diff-989a69580b58016ca079d4bfd33ee67d01abfed1daa239f998819c3708d53c7cL28-R62)

**Other Improvements:**

* The GitHub Actions workflow is updated to use `codecov-action@v4` and explicitly set the Codecov token for coverage uploads.