### PR TITLE
Add support for string and offset arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,90 @@
-# lua-io-writev
+# lua-io-write
 
-[![test](https://github.com/mah0x211/lua-io-writev/actions/workflows/test.yml/badge.svg)](https://github.com/mah0x211/lua-io-writev/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/mah0x211/lua-io-writev/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-io-writev)
+[![test](https://github.com/mah0x211/lua-io-write/actions/workflows/test.yml/badge.svg)](https://github.com/mah0x211/lua-io-write/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/mah0x211/lua-io-write/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-io-write)
 
-Writes data to a specified file descriptor.
+Non-blocking `write(2)` / `writev(2)` for Lua file handles and file descriptors.
 
 
 ## Installation
 
 ```
-luarocks install io-writev
+luarocks install io-write
 ```
 
 ---
 
 ## Error Handling
 
-the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
+The following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## n, err, again, remain = writev( file, data )
+## n [, err, again [, remain]] = write( file, data [, offset] )
 
-writes multiple strings to a file handle or file descriptor using the `writev` system call for efficient vectorized I/O.
+Writes a string or a table of strings to a file handle or file descriptor.
 
-**NOTE**
+- When `data` is a **string**, uses `write(2)` or `pwrite(2)` (if `offset` is given).
+- When `data` is a **table**, uses `writev(2)` or `pwritev(2)` (if `offset` is given) for vectorized I/O. Only positive-integer keys with non-empty string values are written; `nil` values, empty strings, and non-positive-integer keys are ignored. The number of writable entries is limited to the effective `IOV_MAX`, determined as follows:
+  1. If `IOV_MAX` is not defined by the system headers at compile time, `_XOPEN_IOV_MAX` is used if available; otherwise it falls back to `16`.
+  2. At module load time, `sysconf(_SC_IOV_MAX)` is called to get the runtime limit. If it fails or returns a value larger than the compile-time `IOV_MAX`, the compile-time `IOV_MAX` is used instead.
 
-if the non-blocking flag is not set in `file`, then writev function will block until the write operation is completed.
-
+**NOTE:** If the non-blocking flag is not set on `file`, the write will block until completion.
 
 **Parameters**
 
-- `file:file*|integer`: a file handle or a file descriptor.
-- `data:table`: a table containing strings to be written to the file. `nil` entries are treated as empty strings.
+- `file:file*|integer`: a file handle or a raw file descriptor.
+- `data:string|table`: a string, or a table of strings to be written. In a table, `nil` values, empty strings, and non-positive-integer keys are silently skipped.
+- `offset:integer` *(optional)*: byte offset at which to write (`pwrite(2)` / `pwritev(2)`). The file-handle position is not changed. Omit (or pass `nil`) to write at the current position.
 
 **Returns**
 
-- `n:integer`: number of bytes written.
-- `err:any`: error object.
-- `again:boolean`: `true` if the write operation is incomplete with `EAGAIN`, `EWOULDBLOCK` or `EINTR` error.
-- `remain:table`: when `again` is `true`, contains the unwritten data:
-  - If no bytes were written (`EAGAIN`/`EWOULDBLOCK`/`EINTR` immediately), returns the original `data` table.
-  - If partial write occurred, returns a new table containing only the remaining data. The original `data` table is not modified.
+- `n:integer`: number of bytes written, or `nil` on error.
+- `err:any`: error object, or `nil` on success.
+- `again:boolean`: `true` if the write could not complete due to `EAGAIN`, `EWOULDBLOCK`, or `EINTR`. Retry after the fd becomes writable.
+- `remain:table`: *(only when `data` is a table and `again` is `true`)* the data not yet written:
+  - If no bytes were written (pure `EAGAIN`/`EWOULDBLOCK`/`EINTR`), returns the original `data` table unchanged.
+  - If a partial write occurred, returns a new table with the unwritten suffix of the partially-written entry followed by all subsequent entries. The original `data` table is **not** modified.
+
+**Return value summary**
+
+| Situation | Returns |
+|---|---|
+| Full write | `n` |
+| Partial write / EAGAIN (string) | `n, nil, true` |
+| Partial write (table) | `n, nil, true, remain` |
+| EAGAIN with no bytes written (table) | `0, nil, true, data` |
+| Error | `nil, err` |
 
 
 ## Usage
 
 ```lua
-local dump = require('dump')
-local writev = require('io.writev')
-local f = assert(io.tmpfile())
+local write = require('io.write')
 
--- write strings to a file
--- nil is treated as an empty string
-local n, err, again, remain = writev(f, {'hello', ' writev ', nil, 'world'}) 
-while again do
-    -- wait until writable with select/poll/epoll...
-    -- write remaining data
-    n, err, again, remain = writev(f, remain) 
-end
+-- write a string to a tmpfile
+local f = assert(io.tmpfile())
+local n, err = write(f, 'hello world')
+assert(n == 11 and err == nil)
+
+-- write a table of strings
+n, err = write(f, {'hello', ' ', 'world'})
+assert(n == 11 and err == nil)
+
+-- write at a specific byte offset (pwrite/pwritev); FILE* position is unchanged
 f:seek('set')
-print(dump({
-    n = n,
-    err = err,
-    again = again,
-    remain = remain,
-    content = f:read(),
-}))
--- {
---     content = "hello writev world",
---     n = 18
--- }
+n, err = write(f, 'WORLD', 6)  -- overwrites bytes 6-10
+assert(n == 5 and f:seek() == 0)
+
+-- non-blocking write with retry (pipe example)
+local pipe = require('os.pipe')
+local r, w = pipe(true)  -- O_NONBLOCK
+local data = {'hello', ' ', 'world'}
+local again, remain
+n, err, again, remain = write(w:fd(), data)
+while again do
+    -- wait until the fd is writable (select/poll/epoll/kqueue ...)
+    n, err, again, remain = write(w:fd(), remain)
+end
+assert(err == nil)
 ```
+

--- a/src/write.c
+++ b/src/write.c
@@ -1,5 +1,5 @@
 /**
- *  Copyright (C) 2024 Masatoshi Fukunaga
+ *  Copyright (C) 2024-2026 Masatoshi Fukunaga
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to
@@ -19,109 +19,272 @@
  *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  *  IN THE SOFTWARE.
  */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <sys/uio.h>
 #include <unistd.h>
 // lua
 #include <lauxhlib.h>
+#include <lua.h>
 #include <lua_errno.h>
 
-static int writev_lua(lua_State *L)
-{
-    int fd            = -1;
-    struct iovec *iov = NULL;
-    int iovcnt        = 0;
-    size_t total_len  = 0;
-    ssize_t nwritten  = 0;
+#ifndef IOV_MAX
+# ifdef _XOPEN_IOV_MAX
+#  define IOV_MAX _XOPEN_IOV_MAX
+# else
+#  define IOV_MAX 16
+# endif
+#endif
 
-    // check fd
-    if (lauxh_isint(L, 1)) {
-        fd = lauxh_checkint(L, 1);
-    } else {
-        fd = lauxh_fileno(L, 1);
+// sync_fp: resync FILE* position to the current fd position after read(2).
+// Non-seekable fds (pipes, sockets) return -1 from lseek; skip the sync.
+// Returns 0 on success or when skipped, -1 on fseek failure (errno is set).
+static inline int sync_fp(FILE *fp, int fd)
+{
+    if (fp) {
+        off_t pos = lseek(fd, 0, SEEK_CUR);
+        if (pos >= 0) {
+            return fseek(fp, pos, SEEK_SET);
+        }
     }
-    // check iovec table
-    luaL_checktype(L, 2, LUA_TTABLE);
+    return 0; // non-seekable fd; no position to sync
+}
+
+typedef struct {
+    int iovmax;
+    int iovcnt;
+    struct iovec *iov;
+    lua_Integer *idx2key;
+} write_iov_t;
+
+static int push_error_result(lua_State *L, write_iov_t *wiov, ssize_t n)
+{
+    if (n == 0 || errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        // NOTE: report zero-byte write on EAGAIN/EWOULDBLOCK/EINTR to allow
+        // retrying
+        lua_pushinteger(L, 0);
+        if (n != -1) {
+            // zero-byte write; no error
+            return 1;
+        }
+        lua_pushnil(L);
+        lua_pushboolean(L, 1);
+        if (!wiov) {
+            // no iovec; just return the error result
+            return 3;
+        }
+        // just return the original table
+        lua_pushvalue(L, 2);
+        return 4;
+    }
+
+    // other errors
+    lua_pushnil(L);
+    lua_errno_new(L, errno, "write");
+    return 2;
+}
+
+static int push_result(lua_State *L, write_iov_t *wiov, FILE *fp, int fd,
+                       size_t len, ssize_t n)
+{
+    if (n <= 0) {
+        return push_error_result(L, wiov, n);
+    }
+
+    // sync FILE* position to fd position after write; skip for non-seekable fds
+    if (sync_fp(fp, fd) < 0) {
+        // if sync fails, report error but ignore the write result
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "write.sync");
+        return 2;
+    }
+
+    lua_pushinteger(L, n);
+    // fully written
+    if ((size_t)n == len) {
+        return 1;
+    }
+
+    // partial write
+    lua_pushnil(L);
+    lua_pushboolean(L, 1);
+    if (!wiov) {
+        // no iovec
+        return 3;
+    }
+
+    // build remaining table: unwritten suffix of partial entry + all subsequent
+    // entries
+    for (int head = 0; head < wiov->iovcnt; head++) {
+        if ((size_t)n >= wiov->iov[head].iov_len) {
+            // skip fully written entry
+            n -= (ssize_t)wiov->iov[head].iov_len;
+            continue;
+        }
+
+        // Partial write in this entry
+        lua_createtable(L, wiov->iovcnt - head, 0);
+
+        // Add remaining suffix of the head entry
+        lua_rawgeti(L, 2, (int)wiov->idx2key[head]);
+        lua_pushlstring(L, (const char *)wiov->iov[head].iov_base + n,
+                        wiov->iov[head].iov_len - (size_t)n);
+        lua_replace(L, -2);
+        lua_rawseti(L, -2, 1);
+
+        // Add remaining entries after the head entry
+        head++;
+        for (int i = 2; head < wiov->iovcnt; i++, head++) {
+            lua_rawgeti(L, 2, (int)wiov->idx2key[head]);
+            lua_rawseti(L, -2, i);
+        }
+    }
+    return 4;
+}
+
+static int writev_lua(lua_State *L, int fd, FILE *fp, off_t offset,
+                      write_iov_t *wiov)
+{
+    size_t len = 0;
+    ssize_t n  = 0;
+    char empty = 0;
+
+    // validate argument type and count; allow sparse iovec with holes (nil/none
+    // values)
+    lauxh_argcheck(L, lua_istable(L, 2), 2, "string or table expected");
     lua_settop(L, 2);
 
-    // build iovec array
-    iovcnt = lauxh_rawlen(L, 2);
-    iov    = (struct iovec *)lua_newuserdata(L, sizeof(struct iovec) * iovcnt);
-    for (int i = 0; i < iovcnt; i++) {
-        lua_rawgeti(L, 2, i + 1);
-        if (lua_isnoneornil(L, -1)) {
-            // set empty string
-            iov[i].iov_base = "";
-            iov[i].iov_len  = 0;
-        } else if (lua_type(L, -1) != LUA_TSTRING) {
-            return lauxh_argerror(L, 2, "table#%d: string expected, got %s",
-                                  i + 1, luaL_typename(L, -1));
-        } else {
-            iov[i].iov_base = (void *)lua_tolstring(L, -1, &iov[i].iov_len);
+    // build iovec array from Lua strings
+    lua_pushnil(L);
+    while (lua_next(L, 2)) {
+        if (!lauxh_ispint(L, -2)) {
+            // skip non-positive integer keys to allow sparse iovec with holes
+            lua_pop(L, 1);
+            continue;
+        } else if (wiov->iovcnt == wiov->iovmax) {
+            // exceed system limit; fail with EINVAL
+            lua_pushnil(L);
+            lua_errno_new(L, EINVAL, "write.iovcnt");
+            return 2;
         }
-        total_len += iov[i].iov_len;
+
+        wiov->idx2key[wiov->iovcnt] = lua_tointeger(L, -2);
+        switch (lua_type(L, -1)) {
+        case LUA_TSTRING:
+            wiov->iov[wiov->iovcnt].iov_base =
+                (void *)lua_tolstring(L, -1, &wiov->iov[wiov->iovcnt].iov_len);
+            len += wiov->iov[wiov->iovcnt].iov_len;
+            if (wiov->iov[wiov->iovcnt].iov_len > 0) {
+                // insert into sorted position to keep iov ordered by key
+                lua_Integer new_key  = wiov->idx2key[wiov->iovcnt];
+                struct iovec new_iov = wiov->iov[wiov->iovcnt];
+                int j                = wiov->iovcnt - 1;
+                while (j >= 0 && wiov->idx2key[j] > new_key) {
+                    wiov->idx2key[j + 1] = wiov->idx2key[j];
+                    wiov->iov[j + 1]     = wiov->iov[j];
+                    j--;
+                }
+                wiov->idx2key[j + 1] = new_key;
+                wiov->iov[j + 1]     = new_iov;
+                wiov->iovcnt++;
+            }
+        case LUA_TNIL:
+            // skip holes in the iovec
+            break;
+
+        default:
+            return lauxh_argerror(L, 2,
+                                  "table#%d must be string or nil (got %s)",
+                                  lua_tointeger(L, -2), luaL_typename(L, -1));
+        }
         lua_pop(L, 1);
     }
 
-    if (iovcnt == 0) {
-        // no data to write
+    if (wiov->iovcnt < 1) {
+        // nothing to write; succeed with zero-byte write
+        n = (offset >= 0) ? pwrite(fd, &empty, 0, offset) :
+                            write(fd, &empty, 0);
+        if (n < 0) {
+            lua_pushnil(L);
+            lua_errno_new(L, errno, "write");
+            return 2;
+        }
         lua_pushinteger(L, 0);
         return 1;
     }
 
-    nwritten = writev(fd, iov, iovcnt);
-    if (nwritten == -1) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
-            // again - need to merge remaining data
-            lua_pushinteger(L, 0);
-            lua_pushnil(L);
-            lua_pushboolean(L, 1);
-            lua_pushvalue(L, 2);
-            return 4;
-        } else if (errno == EPIPE) {
-            // closed by peer
-            return 0;
-        }
+    n = (offset >= 0) ? pwritev(fd, wiov->iov, wiov->iovcnt, offset) :
+                        writev(fd, wiov->iov, wiov->iovcnt);
+    return push_result(L, wiov, fp, fd, len, n);
+}
+
+static int write_lua(lua_State *L)
+{
+    write_iov_t *wiov = lua_touserdata(L, lua_upvalueindex(1));
+    int fd            = -1;
+    FILE *fp          = NULL;
+    off_t offset      = 0;
+    size_t len        = 0;
+    const char *str   = NULL;
+    ssize_t n         = 0;
+
+    if (lauxh_isint(L, 1)) {
+        fd = lauxh_checkint(L, 1);
+    } else if (!(fp = lauxh_checkfile(L, 1))) {
+        // file has been closed; report EBADF immediately
         lua_pushnil(L);
-        lua_errno_new(L, errno, "writev");
+        lua_errno_new(L, EBADF, "write");
         return 2;
+    } else if (fflush(fp) != 0 && errno != EBADF) {
+        // NOTE: ignore EBADF which means the FILE* is not opened for
+        // writing
+        lua_pushnil(L);
+        lua_errno_new(L, errno, "write.fflush");
+        return 2;
+    } else {
+        fd = fileno(fp);
     }
 
-    // all data written
-    if ((size_t)nwritten == total_len) {
-        lua_pushinteger(L, nwritten);
-        return 1;
+    // get offset: -1 for current fd position, >=0 for pwrite
+    offset = lauxh_optinteger(L, 3, -1);
+
+    if (!lauxh_isstring(L, 2)) {
+        // table of strings; use writev(2)
+        wiov->iovcnt = 0;
+        return writev_lua(L, fd, fp, offset, wiov);
     }
+    lua_settop(L, 2);
 
-    // partial write - remove written data from table
-    lua_pushinteger(L, nwritten);
-    lua_pushnil(L);
-    lua_pushboolean(L, 1);
-    lua_createtable(L, iovcnt, 0); // new table for remaining iovecs
-    for (int i = 0; i < iovcnt; i++) {
-        if (iov[i].iov_len <= (size_t)nwritten) {
-            // skip this iovec
-            nwritten -= iov[i].iov_len;
-            continue;
-        }
-
-        // push remaining data
-        lua_pushlstring(L, (const char *)iov[i].iov_base + nwritten,
-                        iov[i].iov_len - nwritten);
-        lua_rawseti(L, -2, 1);
-        // copy remaining iovecs
-        i++;
-        for (int j = 2; i < iovcnt; i++, j++) {
-            lua_rawgeti(L, 2, i + 1);
-            lua_rawseti(L, -2, j);
-        }
-    }
-
-    return 4;
+    // string argument; use write(2)
+    str = lua_tolstring(L, 2, &len);
+    n   = (offset >= 0) ? pwrite(fd, str, len, offset) : write(fd, str, len);
+    return push_result(L, NULL, fp, fd, len, n);
 }
 
 LUALIB_API int luaopen_io_write(lua_State *L)
 {
+    long iovmax = sysconf(_SC_IOV_MAX);
+
+    if (iovmax < 0 || iovmax > IOV_MAX) {
+        // fallback to a reasonable default if sysconf fails or returns an
+        // unexpected value; this should not happen on compliant systems
+        iovmax = IOV_MAX;
+    }
+
     lua_errno_loadlib(L);
-    lua_pushcfunction(L, writev_lua);
+
+    // allocate write_iov_t as upvalue[1]; iov array as upvalue[2];
+    // idx2key array as upvalue[3]; all three are GC-managed by Lua
+    write_iov_t *wiov = lua_newuserdata(L, sizeof(write_iov_t));
+    wiov->iovcnt      = 0;
+    wiov->iovmax      = (int)iovmax;
+    wiov->iov     = lua_newuserdata(L, (size_t)iovmax * sizeof(struct iovec));
+    wiov->idx2key = lua_newuserdata(L, (size_t)iovmax * sizeof(lua_Integer));
+
+    lua_pushcclosure(L, write_lua, 3);
     return 1;
 }

--- a/test/write_test.lua
+++ b/test/write_test.lua
@@ -1,97 +1,337 @@
 local testcase = require('testcase')
 local assert = require('assert')
-local write = require('io.write')
+local fileno = require('io.fileno')
 local pipe = require('os.pipe')
+local write = require('io.write')
 
-function testcase.write()
-    local r, w, err = pipe(true)
-    assert.is_nil(err)
-    -- calculate the capacity of the pipe
-    local cap = 0
+-- fill a non-blocking write-end until write(2) returns EAGAIN
+local function fill_pipe(wfd)
+    local n, err, again
     repeat
-        local n, _, again = w:write(string.rep('a', 512))
-        cap = cap + n
-    until again
-    r:read(cap)
-
-    -- test that write specified strings to a file
-    local n, again, remain
-    n, err, again, remain = write(w:fd(), {
-        'hello',
-        nil,
-        ' write ',
-        'world',
-    })
+        n, err, again = write(wfd, string.rep('x', 4096))
+    until (n == 0 and again) or err
     assert.is_nil(err)
-    assert.is_nil(again)
-    assert.is_nil(remain)
-    assert.equal(n, 17)
-    assert.equal(r:read(), 'hello write world')
-
-    -- test that return again=true even if a little extra capacity is available.
-    assert(w:write(string.rep('a', cap - 11)))
-    n, err, again, remain = write(w:fd(), {
-        'hello',
-        ' write ',
-        'world',
-    })
-    assert.is_nil(err)
-    assert.is_true(again)
-    assert.equal(remain, {
-        'hello',
-        ' write ',
-        'world',
-    })
-    assert.equal(n, 0)
-
-    -- test that return nil if peer closed
-    r:close()
-    n, err, again, remain = write(w:fd(), {
-        'hello',
-        ' write ',
-        'world',
-    })
-    assert.is_nil(err)
-    assert.is_nil(again)
-    assert.is_nil(n)
-    assert.is_nil(remain)
-
-    -- test that throws an error if invalid file descriptor
-    n, err, again, remain = write(123456789, {
-        'hello',
-        ' write ',
-        'world',
-    })
-    assert.match(err, 'EBADF')
-    assert.is_nil(n)
-    assert.is_nil(again)
-    assert.is_nil(remain)
-
-    -- test that throws an error if no string argument specified
-    err = assert.throws(write, w:fd())
-    assert.match(err, '#2 .+table expected, got no value', false)
-
-    -- test that throws an error if invalid string argument
-    err = assert.throws(write, w:fd(), {
-        'hello',
-        123,
-        'world',
-    })
-    assert.match(err, 'table#2.+string expected, got number', false)
 end
 
-function testcase.write_to_file()
+-- DRAIN must exceed PIPE_BUF on every supported platform so that writes of
+-- DRAIN*2 bytes to a pipe with exactly DRAIN bytes free produce a partial
+-- write rather than EAGAIN.  Linux PIPE_BUF=4096, macOS PIPE_BUF=512.
+-- DRAIN must also be a multiple of PAGE_SIZE (4096) because the Linux kernel
+-- only writes to a pipe in page-aligned increments.
+local DRAIN = 8192
+
+function testcase.write_string()
     local f = assert(io.tmpfile())
 
-    -- test that write to a file
-    local n, err, again = write(f, {
-        'hello',
-        ' write ',
-        'world',
-    })
+    -- test that writing a string returns the byte count
+    local n, err, again = write(f, 'hello world')
+    assert.equal(n, 11)
     assert.is_nil(err)
     assert.is_nil(again)
-    assert.equal(n, 17)
+
+    -- test that the content was written correctly
     f:seek('set')
-    assert.equal(f:read(), 'hello write world')
+    assert.equal(f:read('*a'), 'hello world')
+
+    -- test that writing to a closed file returns EBADF
+    f:close()
+    n, err, again = write(f, 'x')
+    assert.is_nil(n)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+end
+
+function testcase.write_string_to_fd()
+    local f = assert(io.tmpfile())
+    local fd = fileno(f)
+
+    -- test that writing via a raw integer fd returns the byte count
+    local n, err, again = write(fd, 'hello')
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    -- test that the content was written correctly
+    f:seek('set')
+    assert.equal(f:read('*a'), 'hello')
+
+    -- test that writing to an invalid fd returns EBADF
+    n, err, again = write(99999, 'x')
+    assert.is_nil(n)
+    assert.is_nil(again)
+    assert.match(err, 'EBADF')
+
+    f:close()
+end
+
+function testcase.write_string_with_offset()
+    local f = assert(io.tmpfile())
+    f:write('hello world')
+
+    -- test that pwrite writes at the given offset without moving FILE* position
+    f:seek('set')
+    local n, err, again = write(f, 'WORLD', 6)
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    -- test that FILE* position is unchanged after pwrite
+    assert.equal(f:seek(), 0)
+
+    -- test that the content was patched at the correct offset
+    assert.equal(f:read('*a'), 'hello WORLD')
+
+    f:close()
+end
+
+function testcase.write_empty_string()
+    local f = assert(io.tmpfile())
+
+    -- test that writing an empty string returns 0 with no error and no again
+    local n, err, again = write(f, '')
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    f:close()
+end
+
+function testcase.write_interleaved()
+    local f = assert(io.tmpfile())
+
+    -- test that f:write() then write() then f:write() produces correct content,
+    -- confirming that sync_fp keeps the FILE* cursor consistent
+    f:write('foo')
+    local n, err = write(f, 'bar')
+    assert.equal(n, 3)
+    assert.is_nil(err)
+    f:write('baz')
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'foobarbaz')
+
+    -- test that FILE* position is correct after the sequence
+    assert.equal(f:seek(), 9)
+
+    f:close()
+end
+
+function testcase.write_table()
+    local f = assert(io.tmpfile())
+
+    -- test that writing a table of strings concatenates them correctly and
+    -- returns no remaining table on a full write
+    local n, err, again, remaining = write(f, {
+        'hello',
+        ' ',
+        'world',
+    })
+    assert.equal(n, 11)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.is_nil(remaining)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'hello world')
+
+    f:close()
+end
+
+function testcase.write_sparse_table()
+    local f = assert(io.tmpfile())
+
+    -- test that sparse tables (gaps in integer keys) skip the missing entries
+    local n, err, again = write(f, {
+        [1] = 'a',
+        [3] = 'b',
+    })
+    assert.equal(n, 2)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'ab')
+
+    f:close()
+end
+
+function testcase.write_empty_table()
+    local f = assert(io.tmpfile())
+
+    -- test that an empty table returns 0 with no error
+    local n, err, again = write(f, {})
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    f:close()
+end
+
+function testcase.write_table_with_offset()
+    local f = assert(io.tmpfile())
+    f:write('hello world')
+
+    -- test that pwritev writes a table at the given offset without moving FILE* position
+    f:seek('set')
+    local n, err, again = write(f, {
+        'W',
+        'O',
+        'R',
+        'L',
+        'D',
+    }, 6)
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    -- test that FILE* position is unchanged after pwritev
+    assert.equal(f:seek(), 0)
+
+    -- test that the content was patched correctly
+    assert.equal(f:read('*a'), 'hello WORLD')
+
+    f:close()
+end
+
+function testcase.write_table_invalid_type_errors()
+    local f = assert(io.tmpfile())
+
+    -- test that a non-string, non-nil value in a table raises an argument error
+    local ok, err = pcall(write, f, {
+        'a',
+        123,
+    })
+    assert.is_false(ok)
+    assert.match(err, 'table#2')
+
+    f:close()
+end
+
+function testcase.write_table_non_positive_key_skipped()
+    local f = assert(io.tmpfile())
+
+    -- test that a non-positive integer key (0) is skipped; only key 1 is written
+    local n, err, again = write(f, {
+        [0] = 'skip',
+        [1] = 'hello',
+    })
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'hello')
+
+    f:close()
+end
+
+function testcase.write_table_exceeds_iov_max()
+    local f = assert(io.tmpfile())
+
+    -- test that a table with more than IOV_MAX (1024) non-empty entries returns EINVAL
+    local tbl = {}
+    for i = 1, 1025 do
+        tbl[i] = 'x'
+    end
+    local n, err = write(f, tbl)
+    assert.is_nil(n)
+    assert.match(err, 'EINVAL')
+
+    f:close()
+end
+
+function testcase.write_empty_strings_invalid_fd()
+    -- test that a table of only empty strings on an invalid fd returns EBADF:
+    -- all entries have iov_len==0 so iovcnt stays 0, triggering the zero-byte
+    -- write path; the invalid fd makes write(2) fail
+    local n, err = write(99999, {
+        '',
+        '',
+    })
+    assert.is_nil(n)
+    assert.match(err, 'EBADF')
+end
+
+-- A write exceeding PIPE_BUF bytes to a non-blocking pipe with exactly DRAIN
+-- bytes free produces a partial write; the remainder is indicated by again=true.
+function testcase.write_string_nonblock()
+    local r, w = pipe(true)
+    local wfd = w:fd()
+    fill_pipe(wfd)
+
+    -- test that write returns EAGAIN when the pipe is full
+    local n, err, again = write(wfd, 'x')
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    -- drain DRAIN bytes (> PIPE_BUF) to create partial-write space
+    assert.equal(#r:read(DRAIN), DRAIN)
+
+    -- write DRAIN*2 bytes with only DRAIN bytes free → partial write
+    n, err, again = write(wfd, string.rep('a', DRAIN * 2))
+    assert.equal(n, DRAIN)
+    assert.is_nil(err)
+    assert.is_true(again)
+
+    r:close()
+    w:close()
+end
+
+-- writev with a total write exceeding PIPE_BUF bytes on a non-blocking pipe
+-- with limited free space produces partial writes or EAGAIN.
+function testcase.write_table_nonblock()
+    local r, w = pipe(true)
+    local wfd = w:fd()
+    fill_pipe(wfd)
+
+    -- test that EAGAIN returns the original table as the 4th value
+    local n, err, again, remaining = write(wfd, {
+        'foo',
+        'bar',
+    })
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_true(again)
+    assert.is_table(remaining)
+    assert.equal(remaining[1], 'foo')
+    assert.equal(remaining[2], 'bar')
+
+    -- drain DRAIN bytes (> PIPE_BUF); test partial write where the first
+    -- entry fits exactly and the second entry has no room: only second returned
+    assert.equal(#r:read(DRAIN), DRAIN)
+
+    n, err, again, remaining = write(wfd, {
+        string.rep('a', DRAIN),
+        'rest',
+    })
+    assert.equal(n, DRAIN)
+    assert.is_nil(err)
+    assert.is_true(again)
+    assert.is_table(remaining)
+    assert.equal(remaining[1], 'rest')
+    assert.is_nil(remaining[2])
+
+    -- pipe is full again; drain DRAIN bytes and test partial write where the
+    -- first entry fits, the second entry is partially written (DRAIN-512 bytes
+    -- fit out of DRAIN), and the third entry is not written at all.
+    -- entry1(512) + partial entry2(DRAIN-512) = DRAIN bytes written;
+    -- remaining: tail of entry2 = rep('b', 512), all of entry3 = rep('c', 100)
+    assert.equal(#r:read(DRAIN), DRAIN)
+
+    n, err, again, remaining = write(wfd, {
+        string.rep('a', 512),
+        string.rep('b', DRAIN),
+        string.rep('c', 100),
+    })
+    assert.equal(n, DRAIN)
+    assert.is_nil(err)
+    assert.is_true(again)
+    assert.is_table(remaining)
+    assert.equal(remaining[1], string.rep('b', 512))
+    assert.equal(remaining[2], string.rep('c', 100))
+    assert.is_nil(remaining[3])
+
+    r:close()
+    w:close()
 end


### PR DESCRIPTION
This pull request refactors and expands the Lua module for non-blocking file writes, generalizing it from only supporting vectorized writes (`writev`) to supporting both single-string and vectorized writes (`write` and `writev`). The changes include a major rewrite of the implementation and a comprehensive update to the documentation.

**Summary of most important changes:**

### Module and API Generalization

* The module is renamed from `lua-io-writev` to `lua-io-write`, and the API is generalized to support both single-string writes (using `write(2)`/`pwrite(2)`) and vectorized writes (using `writev(2)`/`pwritev(2)`), depending on whether the data argument is a string or a table. (`README.md`, `src/write.c`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R90) [[2]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daR22-R288)

### Documentation Overhaul

* The `README.md` is rewritten to reflect the new generalized API, including detailed explanations of function signatures, parameters, error handling, return values, and usage examples for both string and table data. The documentation now also explains how the module determines the maximum number of iovec entries (`IOV_MAX`).

### Implementation Enhancements

* The C implementation in `src/write.c` is completely refactored:
  - Adds support for both string and table inputs, dispatching to the appropriate system call.
  - Handles non-blocking writes robustly, including partial writes and retry logic.
  - Implements logic to determine the effective `IOV_MAX` at runtime using `sysconf(_SC_IOV_MAX)`, with sensible fallbacks.
  - Ensures correct synchronization of file positions for `FILE*` handles after writes, including error reporting if position sync fails.
  - Handles sparse tables, skips nil/empty/non-integer entries, and returns unwritten data on partial writes without modifying the original input.

### Error Handling Improvements

* Error handling is improved and clarified: all error cases (including partial writes and system call failures) are handled with clear return values and error objects, matching the updated documentation.

### Licensing and Metadata

* Updates copyright/license years and adjusts badge/metadata links in the documentation to reflect the new repository and module name. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R90) [[2]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL2-R2)

These changes modernize the module, make it more flexible and robust, and provide much clearer documentation and usage guidance for end users.