### PR TITLE
Redesign the write() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ luarocks install io-write
 The following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## n [, err, again [, remain]] = write( file, data [, offset] )
+## n, err, again, remain = write( file, data [, offset [, pos]] )
 
 Writes a string or a table of strings to a file handle or file descriptor.
 
 - When `data` is a **string**, uses `write(2)` or `pwrite(2)` (if `offset` is given).
-- When `data` is a **table**, uses `writev(2)` or `pwritev(2)` (if `offset` is given) for vectorized I/O. Only positive-integer keys with non-empty string values are written; `nil` values, empty strings, and non-positive-integer keys are ignored. The number of writable entries is limited to the effective `IOV_MAX`, determined as follows:
+- When `data` is a **table**, uses `writev(2)` or `pwritev(2)` (if `offset` is given) for vectorized I/O. Only positive-integer keys with non-empty string values are written; `nil` values, empty strings, and non-positive-integer keys are ignored. If no entries are written (empty table or all entries consumed by `pos`), a zero-byte `write(2)` is issued to validate the fd. The number of writable entries is limited to the effective `IOV_MAX`, determined as follows:
   1. If `IOV_MAX` is not defined by the system headers at compile time, `_XOPEN_IOV_MAX` is used if available; otherwise it falls back to `16`.
   2. At module load time, `sysconf(_SC_IOV_MAX)` is called to get the runtime limit. If it fails or returns a value larger than the compile-time `IOV_MAX`, the compile-time `IOV_MAX` is used instead.
 
@@ -35,24 +35,22 @@ Writes a string or a table of strings to a file handle or file descriptor.
 - `file:file*|integer`: a file handle or a raw file descriptor.
 - `data:string|table`: a string, or a table of strings to be written. In a table, `nil` values, empty strings, and non-positive-integer keys are silently skipped.
 - `offset:integer` *(optional)*: byte offset at which to write (`pwrite(2)` / `pwritev(2)`). The file-handle position is not changed. Omit (or pass `nil`) to write at the current position.
+- `pos:integer` *(optional, default `0`)*: source-byte position within `data` to start writing from. Use this to resume a partial write without copying or reallocating `data`. Must be `>= 0`. If `pos >= total length of data`, returns `0, nil, nil, 0` without writing any data (an empty string always calls `write(2)` to validate the fd).
 
 **Returns**
 
 - `n:integer`: number of bytes written, or `nil` on error.
 - `err:any`: error object, or `nil` on success.
 - `again:boolean`: `true` if the write could not complete due to `EAGAIN`, `EWOULDBLOCK`, or `EINTR`. Retry after the fd becomes writable.
-- `remain:table`: *(only when `data` is a table and `again` is `true`)* the data not yet written:
-  - If no bytes were written (pure `EAGAIN`/`EWOULDBLOCK`/`EINTR`), returns the original `data` table unchanged.
-  - If a partial write occurred, returns a new table with the unwritten suffix of the partially-written entry followed by all subsequent entries. The original `data` table is **not** modified.
+- `remain:integer`: number of bytes in `data` (starting at `pos`) that were **not** written. `0` on a full write; `> 0` together with `again == true` on a partial write. Always returned when `n` is not `nil`.
 
 **Return value summary**
 
 | Situation | Returns |
 |---|---|
-| Full write | `n` |
-| Partial write / EAGAIN (string) | `n, nil, true` |
-| Partial write (table) | `n, nil, true, remain` |
-| EAGAIN with no bytes written (table) | `0, nil, true, data` |
+| Full write | `n, nil, nil, 0` |
+| Partial write / EAGAIN | `n, nil, true, remain` |
+| pos >= data length | `0, nil, nil, 0` |
 | Error | `nil, err` |
 
 
@@ -75,16 +73,21 @@ f:seek('set')
 n, err = write(f, 'WORLD', 6)  -- overwrites bytes 6-10
 assert(n == 5 and f:seek() == 0)
 
--- non-blocking write with retry (pipe example)
+-- non-blocking write with retry using pos (pipe example)
 local pipe = require('os.pipe')
 local r, w = pipe(true)  -- O_NONBLOCK
-local data = {'hello', ' ', 'world'}
-local again, remain
-n, err, again, remain = write(w:fd(), data)
-while again do
-    -- wait until the fd is writable (select/poll/epoll/kqueue ...)
-    n, err, again, remain = write(w:fd(), remain)
-end
-assert(err == nil)
+local data = string.rep('x', 65536)
+local head = 0
+repeat
+    local again, remain
+    n, err, again, remain = write(w:fd(), data, nil, head)
+    assert(n, err)
+    head = head + n
+    -- remain == 0 when fully written
+    if again then
+        -- wait until the fd is writable (select/poll/epoll/kqueue ...)
+    end
+until remain == 0
+assert(head == #data)
 ```
 

--- a/src/write.c
+++ b/src/write.c
@@ -61,24 +61,21 @@ typedef struct {
     lua_Integer *idx2key;
 } write_iov_t;
 
-static int push_error_result(lua_State *L, write_iov_t *wiov, ssize_t n)
+// push_error_result: push return values when n <= 0.
+// remaining: effective bytes not yet written (passed through from the caller).
+static int push_error_result(lua_State *L, ssize_t n, size_t remaining)
 {
     if (n == 0 || errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
-        // NOTE: report zero-byte write on EAGAIN/EWOULDBLOCK/EINTR to allow
-        // retrying
         lua_pushinteger(L, 0);
-        if (n != -1) {
-            // zero-byte write; no error
-            return 1;
-        }
         lua_pushnil(L);
-        lua_pushboolean(L, 1);
-        if (!wiov) {
-            // no iovec; just return the error result
-            return 3;
+        if (n == -1) {
+            // EAGAIN/EWOULDBLOCK/EINTR: signal the caller to retry
+            lua_pushboolean(L, 1);
+        } else {
+            // zero-byte write returned by the OS; no error, no retry needed
+            lua_pushnil(L);
         }
-        // just return the original table
-        lua_pushvalue(L, 2);
+        lua_pushinteger(L, (lua_Integer)remaining);
         return 4;
     }
 
@@ -88,110 +85,104 @@ static int push_error_result(lua_State *L, write_iov_t *wiov, ssize_t n)
     return 2;
 }
 
-static int push_result(lua_State *L, write_iov_t *wiov, FILE *fp, int fd,
-                       size_t len, ssize_t n)
+// push_result: push return values after a write syscall.
+// len: effective bytes attempted (total data length minus pos).
+// n:   bytes written by the syscall, or <=0 on error/EAGAIN.
+//
+// Always returns exactly 4 values when n > 0:
+//   n, nil, nil,  0        -- fully written
+//   n, nil, true, remain   -- partial write; remain = len - n
+static int push_result(lua_State *L, FILE *fp, int fd, size_t len, ssize_t n)
 {
-    if (n <= 0) {
-        return push_error_result(L, wiov, n);
-    }
+    if (n > 0) {
+        size_t remaining = ((size_t)n < len) ? len - (size_t)n : 0;
 
-    // sync FILE* position to fd position after write; skip for non-seekable fds
-    if (sync_fp(fp, fd) < 0) {
-        // if sync fails, report error but ignore the write result
+        // sync FILE* position to fd position after write; skip for non-seekable
+        // fds
+        if (sync_fp(fp, fd) < 0) {
+            /* LCOV_EXCL_START - fseek failure is not reproducible in tests */
+            lua_pushnil(L);
+            lua_errno_new(L, errno, "write.sync");
+            return 2;
+            /* LCOV_EXCL_STOP */
+        }
+
+        lua_pushinteger(L, n);
         lua_pushnil(L);
-        lua_errno_new(L, errno, "write.sync");
-        return 2;
-    }
-
-    lua_pushinteger(L, n);
-    // fully written
-    if ((size_t)n == len) {
-        return 1;
-    }
-
-    // partial write
-    lua_pushnil(L);
-    lua_pushboolean(L, 1);
-    if (!wiov) {
-        // no iovec
-        return 3;
-    }
-
-    // build remaining table: unwritten suffix of partial entry + all subsequent
-    // entries
-    for (int head = 0; head < wiov->iovcnt; head++) {
-        if ((size_t)n >= wiov->iov[head].iov_len) {
-            // skip fully written entry
-            n -= (ssize_t)wiov->iov[head].iov_len;
-            continue;
+        if (remaining) {
+            lua_pushboolean(L, 1);
+        } else {
+            lua_pushnil(L);
         }
-
-        // Partial write in this entry
-        lua_createtable(L, wiov->iovcnt - head, 0);
-
-        // Add remaining suffix of the head entry
-        lua_rawgeti(L, 2, (int)wiov->idx2key[head]);
-        lua_pushlstring(L, (const char *)wiov->iov[head].iov_base + n,
-                        wiov->iov[head].iov_len - (size_t)n);
-        lua_replace(L, -2);
-        lua_rawseti(L, -2, 1);
-
-        // Add remaining entries after the head entry
-        head++;
-        for (int i = 2; head < wiov->iovcnt; i++, head++) {
-            lua_rawgeti(L, 2, (int)wiov->idx2key[head]);
-            lua_rawseti(L, -2, i);
-        }
+        lua_pushinteger(L, (lua_Integer)remaining);
+        return 4;
     }
-    return 4;
+
+    return push_error_result(L, n, len);
 }
 
 static int writev_lua(lua_State *L, int fd, FILE *fp, off_t offset,
-                      write_iov_t *wiov)
+                      write_iov_t *wiov, lua_Integer pos)
 {
     size_t len = 0;
     ssize_t n  = 0;
     char empty = 0;
 
-    // validate argument type and count; allow sparse iovec with holes (nil/none
-    // values)
+    // validate argument type and count; allow sparse iovec with holes
     lauxh_argcheck(L, lua_istable(L, 2), 2, "string or table expected");
-    lua_settop(L, 2);
+    lua_settop(L, 4);
 
-    // build iovec array from Lua strings
+    // build iovec array from Lua strings, consuming pos bytes during iteration
     lua_pushnil(L);
     while (lua_next(L, 2)) {
         if (!lauxh_ispint(L, -2)) {
-            // skip non-positive integer keys to allow sparse iovec with holes
+            // skip non-positive integer keys
             lua_pop(L, 1);
             continue;
-        } else if (wiov->iovcnt == wiov->iovmax) {
-            // exceed system limit; fail with EINVAL
-            lua_pushnil(L);
-            lua_errno_new(L, EINVAL, "write.iovcnt");
-            return 2;
         }
 
-        wiov->idx2key[wiov->iovcnt] = lua_tointeger(L, -2);
         switch (lua_type(L, -1)) {
-        case LUA_TSTRING:
-            wiov->iov[wiov->iovcnt].iov_base =
-                (void *)lua_tolstring(L, -1, &wiov->iov[wiov->iovcnt].iov_len);
-            len += wiov->iov[wiov->iovcnt].iov_len;
-            if (wiov->iov[wiov->iovcnt].iov_len > 0) {
-                // insert into sorted position to keep iov ordered by key
-                lua_Integer new_key  = wiov->idx2key[wiov->iovcnt];
-                struct iovec new_iov = wiov->iov[wiov->iovcnt];
-                int j                = wiov->iovcnt - 1;
-                while (j >= 0 && wiov->idx2key[j] > new_key) {
-                    wiov->idx2key[j + 1] = wiov->idx2key[j];
-                    wiov->iov[j + 1]     = wiov->iov[j];
-                    j--;
-                }
-                wiov->idx2key[j + 1] = new_key;
-                wiov->iov[j + 1]     = new_iov;
-                wiov->iovcnt++;
+        case LUA_TSTRING: {
+            lua_Integer new_key = lua_tointeger(L, -2);
+            size_t iov_len      = 0;
+            char *iov_base      = (char *)lua_tolstring(L, -1, &iov_len);
+            int idx             = 0;
+
+            if ((lua_Integer)iov_len <= pos) {
+                // this entry is fully covered by pos; skip it
+                pos -= (lua_Integer)iov_len;
+                lua_pop(L, 1);
+                continue;
+            } else if (wiov->iovcnt == wiov->iovmax) {
+                // exceed system limit; fail with EINVAL
+                lua_pushnil(L);
+                lua_errno_new(L, EINVAL, "write.iovcnt");
+                return 2;
             }
+            iov_len -= (size_t)pos;
+            iov_base += (size_t)pos;
+            pos = 0;
+            len += iov_len;
+            wiov->iov[wiov->iovcnt] = (struct iovec){
+                .iov_base = iov_base,
+                .iov_len  = iov_len,
+            };
+
+            // insert into sorted position to keep iov ordered by key
+            wiov->idx2key[wiov->iovcnt] = new_key;
+            for (idx = wiov->iovcnt - 1;
+                 idx >= 0 && wiov->idx2key[idx] > new_key; idx--) {
+                wiov->idx2key[idx + 1] = wiov->idx2key[idx];
+                wiov->iov[idx + 1]     = wiov->iov[idx];
+            }
+            wiov->idx2key[idx + 1] = new_key;
+            wiov->iov[idx + 1]     = (struct iovec){
+                .iov_base = iov_base,
+                .iov_len  = iov_len,
+            };
+            wiov->iovcnt++;
+            break;
+        }
         case LUA_TNIL:
             // skip holes in the iovec
             break;
@@ -205,7 +196,8 @@ static int writev_lua(lua_State *L, int fd, FILE *fp, off_t offset,
     }
 
     if (wiov->iovcnt < 1) {
-        // nothing to write; succeed with zero-byte write
+        // empty table (or all entries consumed by pos): zero-byte write to
+        // validate the fd
         n = (offset >= 0) ? pwrite(fd, &empty, 0, offset) :
                             write(fd, &empty, 0);
         if (n < 0) {
@@ -214,12 +206,16 @@ static int writev_lua(lua_State *L, int fd, FILE *fp, off_t offset,
             return 2;
         }
         lua_pushinteger(L, 0);
-        return 1;
+        lua_pushnil(L);
+        lua_pushnil(L);
+        lua_pushinteger(L, 0);
+        return 4;
     }
 
+    // iov is already trimmed by pos; len is the effective byte count
     n = (offset >= 0) ? pwritev(fd, wiov->iov, wiov->iovcnt, offset) :
                         writev(fd, wiov->iov, wiov->iovcnt);
-    return push_result(L, wiov, fp, fd, len, n);
+    return push_result(L, fp, fd, len, n);
 }
 
 static int write_lua(lua_State *L)
@@ -228,6 +224,7 @@ static int write_lua(lua_State *L)
     int fd            = -1;
     FILE *fp          = NULL;
     off_t offset      = 0;
+    lua_Integer pos   = 0;
     size_t len        = 0;
     const char *str   = NULL;
     ssize_t n         = 0;
@@ -242,27 +239,45 @@ static int write_lua(lua_State *L)
     } else if (fflush(fp) != 0 && errno != EBADF) {
         // NOTE: ignore EBADF which means the FILE* is not opened for
         // writing
+        /* LCOV_EXCL_START - fflush non-EBADF failure requires mocking */
         lua_pushnil(L);
         lua_errno_new(L, errno, "write.fflush");
         return 2;
+        /* LCOV_EXCL_STOP */
     } else {
         fd = fileno(fp);
     }
 
     // get offset: -1 for current fd position, >=0 for pwrite
     offset = lauxh_optinteger(L, 3, -1);
+    // get pos: source-byte position to start writing from (default 0)
+    pos    = lauxh_optuinteger(L, 4, 0);
 
     if (!lauxh_isstring(L, 2)) {
         // table of strings; use writev(2)
         wiov->iovcnt = 0;
-        return writev_lua(L, fd, fp, offset, wiov);
+        return writev_lua(L, fd, fp, offset, wiov, pos);
     }
     lua_settop(L, 2);
 
     // string argument; use write(2)
     str = lua_tolstring(L, 2, &len);
-    n   = (offset >= 0) ? pwrite(fd, str, len, offset) : write(fd, str, len);
-    return push_result(L, NULL, fp, fd, len, n);
+
+    // apply pos: skip bytes already written by the caller.
+    // for empty string (len==0), fall through to call write(2) so that an
+    // invalid fd is still detected (same behaviour as before pos was added).
+    if (len > 0 && (size_t)pos >= len) {
+        lua_pushinteger(L, 0);
+        lua_pushnil(L);
+        lua_pushnil(L);
+        lua_pushinteger(L, 0);
+        return 4;
+    }
+    str += (size_t)pos;
+    len -= (size_t)pos;
+
+    n = (offset >= 0) ? pwrite(fd, str, len, offset) : write(fd, str, len);
+    return push_result(L, fp, fd, len, n);
 }
 
 LUALIB_API int luaopen_io_write(lua_State *L)
@@ -272,7 +287,9 @@ LUALIB_API int luaopen_io_write(lua_State *L)
     if (iovmax < 0 || iovmax > IOV_MAX) {
         // fallback to a reasonable default if sysconf fails or returns an
         // unexpected value; this should not happen on compliant systems
+        /* LCOV_EXCL_START - sysconf failure is not reproducible in tests */
         iovmax = IOV_MAX;
+        /* LCOV_EXCL_STOP */
     }
 
     lua_errno_loadlib(L);

--- a/test/write_test.lua
+++ b/test/write_test.lua
@@ -129,7 +129,7 @@ function testcase.write_table()
     assert.equal(n, 11)
     assert.is_nil(err)
     assert.is_nil(again)
-    assert.is_nil(remaining)
+    assert.equal(remaining, 0)
 
     f:seek('set')
     assert.equal(f:read('*a'), 'hello world')
@@ -260,19 +260,21 @@ function testcase.write_string_nonblock()
     fill_pipe(wfd)
 
     -- test that write returns EAGAIN when the pipe is full
-    local n, err, again = write(wfd, 'x')
+    local n, err, again, remaining = write(wfd, 'x')
     assert.equal(n, 0)
     assert.is_nil(err)
     assert.is_true(again)
+    assert.equal(remaining, 1)
 
     -- drain DRAIN bytes (> PIPE_BUF) to create partial-write space
     assert.equal(#r:read(DRAIN), DRAIN)
 
     -- write DRAIN*2 bytes with only DRAIN bytes free → partial write
-    n, err, again = write(wfd, string.rep('a', DRAIN * 2))
+    n, err, again, remaining = write(wfd, string.rep('a', DRAIN * 2))
     assert.equal(n, DRAIN)
     assert.is_nil(err)
     assert.is_true(again)
+    assert.equal(remaining, DRAIN)
 
     r:close()
     w:close()
@@ -285,7 +287,8 @@ function testcase.write_table_nonblock()
     local wfd = w:fd()
     fill_pipe(wfd)
 
-    -- test that EAGAIN returns the original table as the 4th value
+    -- test that EAGAIN returns the unwritten byte count as the 4th value
+    -- (6 bytes: 'foo'(3) + 'bar'(3))
     local n, err, again, remaining = write(wfd, {
         'foo',
         'bar',
@@ -293,12 +296,11 @@ function testcase.write_table_nonblock()
     assert.equal(n, 0)
     assert.is_nil(err)
     assert.is_true(again)
-    assert.is_table(remaining)
-    assert.equal(remaining[1], 'foo')
-    assert.equal(remaining[2], 'bar')
+    assert.equal(remaining, 6)
 
-    -- drain DRAIN bytes (> PIPE_BUF); test partial write where the first
-    -- entry fits exactly and the second entry has no room: only second returned
+    -- drain DRAIN bytes (> PIPE_BUF); test partial write where the first entry
+    -- (DRAIN bytes) fits exactly and the second entry ('rest', 4 bytes) has no
+    -- room: remaining == 4
     assert.equal(#r:read(DRAIN), DRAIN)
 
     n, err, again, remaining = write(wfd, {
@@ -308,15 +310,11 @@ function testcase.write_table_nonblock()
     assert.equal(n, DRAIN)
     assert.is_nil(err)
     assert.is_true(again)
-    assert.is_table(remaining)
-    assert.equal(remaining[1], 'rest')
-    assert.is_nil(remaining[2])
+    assert.equal(remaining, 4)
 
-    -- pipe is full again; drain DRAIN bytes and test partial write where the
-    -- first entry fits, the second entry is partially written (DRAIN-512 bytes
-    -- fit out of DRAIN), and the third entry is not written at all.
-    -- entry1(512) + partial entry2(DRAIN-512) = DRAIN bytes written;
-    -- remaining: tail of entry2 = rep('b', 512), all of entry3 = rep('c', 100)
+    -- pipe is full again; drain DRAIN bytes and test partial write where
+    -- entry1(512) + partial entry2(DRAIN-512 of DRAIN bytes) = DRAIN written;
+    -- remaining = (512 + DRAIN + 100) - DRAIN = 612
     assert.equal(#r:read(DRAIN), DRAIN)
 
     n, err, again, remaining = write(wfd, {
@@ -327,11 +325,160 @@ function testcase.write_table_nonblock()
     assert.equal(n, DRAIN)
     assert.is_nil(err)
     assert.is_true(again)
-    assert.is_table(remaining)
-    assert.equal(remaining[1], string.rep('b', 512))
-    assert.equal(remaining[2], string.rep('c', 100))
-    assert.is_nil(remaining[3])
+    assert.equal(remaining, 612)
 
     r:close()
     w:close()
+end
+
+function testcase.write_string_pos()
+    local f = assert(io.tmpfile())
+
+    -- test writing from the middle of a string using pos (skip first 6 bytes)
+    local n, err, again, remaining = write(f, 'hello world', nil, 6)
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'world')
+
+    f:close()
+end
+
+function testcase.write_string_pos_at_end()
+    local f = assert(io.tmpfile())
+
+    -- test that pos == len returns 0 with no error and no syscall
+    local n, err, again, remaining = write(f, 'hello', nil, 5)
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    -- test that pos > len also returns 0
+    n, err, again, remaining = write(f, 'hello', nil, 10)
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:close()
+end
+
+function testcase.write_string_pos_invalid()
+    local f = assert(io.tmpfile())
+
+    -- test that a negative pos argument raises an argument error
+    local ok, err = pcall(write, f, 'hello', nil, -1)
+    assert.is_false(ok)
+    assert.match(err, '#4')
+
+    f:close()
+end
+
+function testcase.write_table_pos()
+    local f = assert(io.tmpfile())
+
+    -- test that pos=6 skips 'hello'(5) + ' '(1) and writes only 'world'(5)
+    local n, err, again, remaining = write(f, {
+        'hello',
+        ' ',
+        'world',
+    }, nil, 6)
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'world')
+
+    -- test that pos falls inside an entry: skip 'abc'(3)+'d'(1) of 'def',
+    -- writing 'ef'+'ghi' = 5 bytes
+    f:seek('set')
+    n, err, again, remaining = write(f, {
+        'abc',
+        'def',
+        'ghi',
+    }, nil, 4)
+    assert.equal(n, 5)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'efghi')
+
+    f:close()
+end
+
+function testcase.write_table_pos_at_end()
+    local f = assert(io.tmpfile())
+
+    -- test that pos == total len returns 0 with no syscall
+    local n, err, again, remaining = write(f, {
+        'hello',
+        ' ',
+        'world',
+    }, nil, 11)
+    assert.equal(n, 0)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:close()
+end
+
+function testcase.write_string_nonblock_retry_with_pos()
+    local r, w = pipe(true)
+    local wfd = w:fd()
+    fill_pipe(wfd)
+
+    -- drain DRAIN bytes so the pipe has DRAIN bytes free
+    assert.equal(#r:read(DRAIN), DRAIN)
+
+    -- attempt to write DRAIN*2 bytes; only DRAIN bytes fit (partial write)
+    local data = string.rep('x', DRAIN * 2)
+    local n, err, again, remaining = write(wfd, data)
+    assert.equal(n, DRAIN)
+    assert.is_nil(err)
+    assert.is_true(again)
+    assert.equal(remaining, DRAIN)
+
+    -- drain the pipe, then retry using pos = n to skip the already-written bytes
+    assert.equal(#r:read(DRAIN * 2), DRAIN * 2)
+    n, err, again, remaining = write(wfd, data, nil, DRAIN)
+    assert.equal(n, DRAIN)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    r:close()
+    w:close()
+end
+
+function testcase.write_table_hash_ordered()
+    local f = assert(io.tmpfile())
+
+    -- Force reverse-key iteration via hash-bucket ordering: both 1025 and 1030
+    -- hash to bucket 0 in Lua 5.1's 2-entry hash table, so inserting 1030
+    -- first puts it at node[0] and 1025 at node[1]. lua_next returns 1030
+    -- before 1025, triggering the insertion sort shift body that keeps the
+    -- iovec ordered by key value.
+    local data = {}
+    data[1030] = 'b'
+    data[1025] = 'a'
+
+    local n, err, again, remaining = write(f, data)
+    assert.equal(n, 2)
+    assert.is_nil(err)
+    assert.is_nil(again)
+    assert.equal(remaining, 0)
+
+    f:seek('set')
+    assert.equal(f:read('*a'), 'ab')
+
+    f:close()
 end


### PR DESCRIPTION
This pull request refactors the return value handling of the `write` function (and related vectorized writes) to consistently return the number of unwritten bytes as the fourth return value, rather than returning a table of remaining data. It also introduces a new `pos` parameter to allow partial writes to resume from a specific byte offset, improving support for non-blocking and partial-write scenarios. The documentation and tests are updated to reflect these changes.

The most important changes are:

**API and Return Value Changes:**

* The `write` function now always returns four values: `n, err, again, remain`, where `remain` is the number of bytes not yet written (was previously a table for vector writes). This makes the API simpler and more predictable. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R53) [[3]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL64-R78) [[4]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL91-R153)
* The new optional `pos` parameter allows specifying the source-byte position within the data to start writing from, enabling efficient resumption of partial writes without copying or reallocating data. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R53) [[3]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daR227) [[4]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daR242-R280)

**Implementation Updates:**

* The C implementation in `src/write.c` is refactored so that both string and table writes use the same return value convention, and the logic for handling partial writes, empty tables, and the new `pos` parameter is unified and clarified. [[1]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL64-R78) [[2]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL91-R153) [[3]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daR162-R184) [[4]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL208-R200) [[5]](diffhunk://#diff-ac2b16ad23e0d1236267855db34c222593e541b67af86077f29cc7d4809539daL217-R218)

**Documentation and Usage Example Updates:**

* The `README.md` is updated to describe the new return value format and the `pos` parameter, including updated usage examples for non-blocking writes. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R27) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R53) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R91)

**Test Suite Updates:**

* The test suite is updated to check the new return value structure, including the unwritten byte count for partial and failed writes, and to use the `pos` parameter in relevant scenarios. [[1]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L132-R132) [[2]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L263-R277) [[3]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L288-R303) [[4]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L311-R317)

These changes make the `write` API more consistent, easier to use for partial and non-blocking writes, and better documented.