### PR TITLE
Swap the order of pos and offset arguments in write()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ luarocks install io-write
 The following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## n, err, again, remain = write( file, data [, offset [, pos]] )
+## n, err, again, remain = write( file, data [, pos [, offset]] )
 
 Writes a string or a table of strings to a file handle or file descriptor.
 
@@ -34,8 +34,8 @@ Writes a string or a table of strings to a file handle or file descriptor.
 
 - `file:file*|integer`: a file handle or a raw file descriptor.
 - `data:string|table`: a string, or a table of strings to be written. In a table, `nil` values, empty strings, and non-positive-integer keys are silently skipped.
-- `offset:integer` *(optional)*: byte offset at which to write (`pwrite(2)` / `pwritev(2)`). The file-handle position is not changed. Omit (or pass `nil`) to write at the current position.
 - `pos:integer` *(optional, default `0`)*: source-byte position within `data` to start writing from. Use this to resume a partial write without copying or reallocating `data`. Must be `>= 0`. If `pos >= total length of data`, returns `0, nil, nil, 0` without writing any data (an empty string always calls `write(2)` to validate the fd).
+- `offset:integer` *(optional)*: byte offset at which to write (`pwrite(2)` / `pwritev(2)`). The file-handle position is not changed. Omit (or pass `nil`) to write at the current position.
 
 **Returns**
 
@@ -70,7 +70,7 @@ assert(n == 11 and err == nil)
 
 -- write at a specific byte offset (pwrite/pwritev); FILE* position is unchanged
 f:seek('set')
-n, err = write(f, 'WORLD', 6)  -- overwrites bytes 6-10
+n, err = write(f, 'WORLD', nil, 6)  -- overwrites bytes 6-10
 assert(n == 5 and f:seek() == 0)
 
 -- non-blocking write with retry using pos (pipe example)
@@ -80,7 +80,7 @@ local data = string.rep('x', 65536)
 local head = 0
 repeat
     local again, remain
-    n, err, again, remain = write(w:fd(), data, nil, head)
+    n, err, again, remain = write(w:fd(), data, head)
     assert(n, err)
     head = head + n
     -- remain == 0 when fully written

--- a/src/write.c
+++ b/src/write.c
@@ -130,7 +130,7 @@ static int writev_lua(lua_State *L, int fd, FILE *fp, off_t offset,
 
     // validate argument type and count; allow sparse iovec with holes
     lauxh_argcheck(L, lua_istable(L, 2), 2, "string or table expected");
-    lua_settop(L, 4);
+    lua_settop(L, 2);
 
     // build iovec array from Lua strings, consuming pos bytes during iteration
     lua_pushnil(L);
@@ -243,10 +243,10 @@ static int write_lua(lua_State *L)
         fd = fileno(fp);
     }
 
-    // get offset: -1 for current fd position, >=0 for pwrite
-    offset = lauxh_optinteger(L, 3, -1);
     // get pos: source-byte position to start writing from (default 0)
-    pos    = lauxh_optuinteger(L, 4, 0);
+    pos    = lauxh_optuinteger(L, 3, 0);
+    // get offset: -1 for current fd position, >=0 for pwrite
+    offset = lauxh_optinteger(L, 4, -1);
 
     if (!lauxh_isstring(L, 2)) {
         // table of strings; use writev(2)

--- a/test/write_test.lua
+++ b/test/write_test.lua
@@ -70,7 +70,7 @@ function testcase.write_string_with_offset()
 
     -- test that pwrite writes at the given offset without moving FILE* position
     f:seek('set')
-    local n, err, again = write(f, 'WORLD', 6)
+    local n, err, again = write(f, 'WORLD', nil, 6)
     assert.equal(n, 5)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -179,7 +179,7 @@ function testcase.write_table_with_offset()
         'R',
         'L',
         'D',
-    }, 6)
+    }, nil, 6)
     assert.equal(n, 5)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -335,7 +335,7 @@ function testcase.write_string_pos()
     local f = assert(io.tmpfile())
 
     -- test writing from the middle of a string using pos (skip first 6 bytes)
-    local n, err, again, remaining = write(f, 'hello world', nil, 6)
+    local n, err, again, remaining = write(f, 'hello world', 6)
     assert.equal(n, 5)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -351,14 +351,14 @@ function testcase.write_string_pos_at_end()
     local f = assert(io.tmpfile())
 
     -- test that pos == len returns 0 with no error and no syscall
-    local n, err, again, remaining = write(f, 'hello', nil, 5)
+    local n, err, again, remaining = write(f, 'hello', 5)
     assert.equal(n, 0)
     assert.is_nil(err)
     assert.is_nil(again)
     assert.equal(remaining, 0)
 
     -- test that pos > len also returns 0
-    n, err, again, remaining = write(f, 'hello', nil, 10)
+    n, err, again, remaining = write(f, 'hello', 10)
     assert.equal(n, 0)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -371,9 +371,9 @@ function testcase.write_string_pos_invalid()
     local f = assert(io.tmpfile())
 
     -- test that a negative pos argument raises an argument error
-    local ok, err = pcall(write, f, 'hello', nil, -1)
+    local ok, err = pcall(write, f, 'hello', -1)
     assert.is_false(ok)
-    assert.match(err, '#4')
+    assert.match(err, '#3')
 
     f:close()
 end
@@ -386,7 +386,7 @@ function testcase.write_table_pos()
         'hello',
         ' ',
         'world',
-    }, nil, 6)
+    }, 6)
     assert.equal(n, 5)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -402,7 +402,7 @@ function testcase.write_table_pos()
         'abc',
         'def',
         'ghi',
-    }, nil, 4)
+    }, 4)
     assert.equal(n, 5)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -422,7 +422,7 @@ function testcase.write_table_pos_at_end()
         'hello',
         ' ',
         'world',
-    }, nil, 11)
+    }, 11)
     assert.equal(n, 0)
     assert.is_nil(err)
     assert.is_nil(again)
@@ -449,7 +449,7 @@ function testcase.write_string_nonblock_retry_with_pos()
 
     -- drain the pipe, then retry using pos = n to skip the already-written bytes
     assert.equal(#r:read(DRAIN * 2), DRAIN * 2)
-    n, err, again, remaining = write(wfd, data, nil, DRAIN)
+    n, err, again, remaining = write(wfd, data, DRAIN)
     assert.equal(n, DRAIN)
     assert.is_nil(err)
     assert.is_nil(again)


### PR DESCRIPTION
This pull request updates the argument order for the `write` function, making the `pos` (source-byte position) argument come before the `offset` (file offset) argument. The change is reflected in the implementation, documentation, and all relevant tests for consistency and clarity. This should make the function signature more intuitive and reduce confusion for users.

Most important changes:

**API and Implementation Updates:**
* Changed the `write` function signature so that `pos` is now the third argument and `offset` is the fourth; updated the C implementation accordingly in `src/write.c`.
* Adjusted the internal handling of arguments in the `writev_lua` helper to match the new argument order.

**Documentation Updates:**
* Updated the function signature and argument descriptions in `README.md` to reflect the new argument order, ensuring that `pos` precedes `offset`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L37-R38)
* Revised code examples in `README.md` to use the new argument order. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L83-R83)

**Test Suite Updates:**
* Updated all test cases in `test/write_test.lua` to use the new argument order, including both string and table write scenarios, and adjusted error checking to reflect the new positions. [[1]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L73-R73) [[2]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L182-R182) [[3]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L338-R338) [[4]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L354-R361) [[5]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L374-R376) [[6]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L389-R389) [[7]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L405-R405) [[8]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L425-R425) [[9]](diffhunk://#diff-3ed6d26d5031a62998e676efd83f4b4e4e6f81dd9299970e09bfe368382639e5L452-R452)